### PR TITLE
page-links页面在https网站用http引用外部资源fix，group成员联系方式可隐藏

### DIFF
--- a/layout/_widget/page-links.ejs
+++ b/layout/_widget/page-links.ejs
@@ -1,5 +1,5 @@
-<link href="http://cdn.bootcss.com/bootstrap/3.3.7/css/bootstrap.min.css" rel="stylesheet">
-<link href="http://cdn.bootcss.com/font-awesome/4.6.3/css/font-awesome.min.css" rel="stylesheet">
+<link href="//cdn.bootcss.com/bootstrap/3.3.7/css/bootstrap.min.css" rel="stylesheet">
+<link href="//cdn.bootcss.com/font-awesome/4.6.3/css/font-awesome.min.css" rel="stylesheet">
 <link rel="stylesheet" type="text/css" href="/css/demo.css">
 <style type="text/css">
     .our-team {
@@ -146,10 +146,18 @@
                                                     <Span class="post"><%= site.data.links[i].descr %></Span>
                                                 </div>
                                                 <ul class="social">
-                                                    <li><a href="<%= site.data.links[i].link%>" class="fa fa-link"></a></li>
-                                                    <li><a href="<%= site.data.links[i].qq%>" class="fa fa-qq"></a></li>
-                                                    <li><a href="<%= site.data.links[i].wachat%>" class="fa fa-wechat"></a></li>
-                                                    <li><a href="<%= site.data.links[i].weibo%>" class="fa fa-weibo"></a></li>
+                                                    <% if (site.data.links[i].link != null) { %>
+                                                        <li><a href="<%= site.data.links[i].link%>" class="fa fa-link"></a></li>
+                                                    <%}%>
+                                                    <% if (site.data.links[i].qq != null) { %>
+                                                        <li><a href="<%= site.data.links[i].qq%>" class="fa fa-qq"></a></li>
+                                                    <%}%>
+                                                    <% if (site.data.links[i].wachat != null) { %>
+                                                        <li><a href="<%= site.data.links[i].wachat%>" class="fa fa-wechat"></a></li>
+                                                    <%}%>
+                                                    <% if (site.data.links[i].weibo != null) { %>
+                                                        <li><a href="<%= site.data.links[i].weibo%>" class="fa fa-weibo"></a></li>
+                                                    <%}%>
                                                 </ul>
                                             </div>
                                         </div>


### PR DESCRIPTION
1、修复了https网站引用 ‘bootstrap.min.css’ 和 ‘font-awesome.min.css’ 文件错误的问题

![image](https://user-images.githubusercontent.com/10628338/40316361-b0dd89be-5d50-11e8-83e6-5511420efcb3.png)

2、links.yml不配置属性link/qq/wachat/weibo则不显示图标

![image](https://user-images.githubusercontent.com/10628338/40361024-879fcbf2-5dfa-11e8-922e-f2a26b4c3441.png)

![image](https://user-images.githubusercontent.com/10628338/40361011-7dbd6eb4-5dfa-11e8-945b-66b7676f2b57.png)

![image](https://user-images.githubusercontent.com/10628338/40361045-94a62dd2-5dfa-11e8-863a-dbf3a07b8bb0.png)
